### PR TITLE
Add license tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setuptools.setup(
     author="Nicolas Gres",
     author_email="nicolas@gres.io",
     description="Unofficial Rademacher HomePilot API wrapper",
+    license="MIT",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/nico0302/pyhomepilot",


### PR DESCRIPTION
Allow third-party tools (e. g., PyPI or `pyp2rpm`) to get the license details in a simple way.